### PR TITLE
ウォレットを持っていないユーザにもメッセージとユーザプロフィールを表示する

### DIFF
--- a/contract/front/src/app/page.tsx
+++ b/contract/front/src/app/page.tsx
@@ -14,8 +14,10 @@ export default function Home() {
   const [showEchoList, setShowEchoList] = useState(false);
 
   const fetchAllEchoes = async () => {
+    setIsLoading(true);
     const echoes: ProcessedEcho[] | null = await getAllEchoes();
     if (echoes) setAllEchoes(echoes.sort((a, b) => b.id - a.id));
+    setIsLoading(false);
   };
 
   useEffect(() => {

--- a/contract/front/src/app/types/type.ts
+++ b/contract/front/src/app/types/type.ts
@@ -4,6 +4,14 @@ export interface EchoDetailsProps {
   linkTo?: string;
 }
 
+// ブロックチェーンから取得する生のEchoデータ（チェーン上に保存）
+export interface RawEcho {
+  id: number;
+  echoer: string;
+  cid: string;
+  timestamp: number;
+}
+
 export interface ProcessedEcho {
   id: number;
   address: string;

--- a/contract/front/src/app/users/[address]/page.tsx
+++ b/contract/front/src/app/users/[address]/page.tsx
@@ -58,7 +58,6 @@ export default function UserProfile({ params }: { params: { address: string } })
   }
 
   useEffect(() => {
-    setIsLoading(true);
     // 自分のウォレットアドレスを
     const checkWalletConnection = async() => {
       const account = await connectWallet()
@@ -68,7 +67,6 @@ export default function UserProfile({ params }: { params: { address: string } })
     checkWalletConnection();
 
     fetchProfile(params.address);
-    setIsLoading(false);
   }, [params.address]);
 
   // ウォレットに接続済みかつ自分のアカウントのみ編集できる

--- a/contract/front/src/utils/ethereumUtils.ts
+++ b/contract/front/src/utils/ethereumUtils.ts
@@ -127,30 +127,3 @@ export const removeEcho = async (echoId: number): Promise<boolean> => {
     throw error;
   }
 }
-
-// 関数に渡される関数→コールバック関数
-// 受け取る関数は引数を3つ取り、戻り値はvoid
-// export const setupEchoListener = (callback: (from: string, timestamp: number, cid: string) => void): (() => void) | undefined => {
-//   getEthEchoContract().then(contract => {
-//     if (contract) {
-//       // スマートコントラクタからNewEchoが呼ばれるたびにcallbackを実行
-//       contract.on("NewEcho", callback);
-//       // イベントリスナーを解除する
-//       return () => contract.off("NewEcho", callback);
-//     }
-//   });
-
-//   return undefined;
-// };
-
-// DeleteEchoイベントをリッスンし、Echoが削除されたときにコールバック関数を実行
-// export const setupDeleteEchoListener = (callback: (echoId: number, from: string) => void): (() => void) | undefined => {
-//   getEthEchoContract().then(contract => {
-//     if (contract) {
-//       contract.on("DeleteEcho", callback);
-//       return () => contract.off("DeleteEcho", callback);
-//     }
-//   });
-
-//   return undefined;
-// };

--- a/contract/front/src/utils/ethereumUtils.ts
+++ b/contract/front/src/utils/ethereumUtils.ts
@@ -1,10 +1,6 @@
 import { ethers } from "ethers";
 import abi from "../app/utils/EthEcho.json";
-// import { create } from 'kubo-rpc-client';
-import dotenv from 'dotenv';
 import { ProcessedEcho, RawEcho } from "@/app/types/type";
-
-dotenv.config();
 
 const contractAddress = "0x3Cd556A69C4908Cd1034d29c10D6250E712F1EB3";
 const contractABI = abi.abi;
@@ -29,7 +25,7 @@ export const connectWallet = async (): Promise<string | null> => {
   }
 };
 
-export const getEthEchoContract = async () => {
+const getEthEchoContract = async () => {
   const ethereum = getEthereumObject();
   if (!ethereum) return null;
 
@@ -37,6 +33,18 @@ export const getEthEchoContract = async () => {
   const signer = await provider.getSigner();
   return new ethers.Contract(contractAddress, contractABI, signer);
 };
+
+// 読み取り専用のコントラクト
+const getReadOnlyContract = async () => {
+  const provider = new ethers.JsonRpcProvider("https://eth-sepolia.g.alchemy.com/v2/0f3pgdhbIActNECtmQus8qUy6Gl6HbwT");
+    
+  // コントラクトのインスタンス化
+  return new ethers.Contract(
+    contractAddress,
+    contractABI,
+    provider
+  );
+}
 
 export const writeEchoContract = async (message: string) => {
   const contract = await getEthEchoContract();
@@ -70,7 +78,7 @@ export const writeEchoContract = async (message: string) => {
 };
 
 export const getAllEchoes = async (): Promise<ProcessedEcho[] | null> => {
-  const contract = await getEthEchoContract();
+  const contract = await getReadOnlyContract();
   if (!contract) return null;
 
   try {
@@ -122,27 +130,27 @@ export const removeEcho = async (echoId: number): Promise<boolean> => {
 
 // 関数に渡される関数→コールバック関数
 // 受け取る関数は引数を3つ取り、戻り値はvoid
-export const setupEchoListener = (callback: (from: string, timestamp: number, cid: string) => void): (() => void) | undefined => {
-  getEthEchoContract().then(contract => {
-    if (contract) {
-      // スマートコントラクタからNewEchoが呼ばれるたびにcallbackを実行
-      contract.on("NewEcho", callback);
-      // イベントリスナーを解除する
-      return () => contract.off("NewEcho", callback);
-    }
-  });
+// export const setupEchoListener = (callback: (from: string, timestamp: number, cid: string) => void): (() => void) | undefined => {
+//   getEthEchoContract().then(contract => {
+//     if (contract) {
+//       // スマートコントラクタからNewEchoが呼ばれるたびにcallbackを実行
+//       contract.on("NewEcho", callback);
+//       // イベントリスナーを解除する
+//       return () => contract.off("NewEcho", callback);
+//     }
+//   });
 
-  return undefined;
-};
+//   return undefined;
+// };
 
 // DeleteEchoイベントをリッスンし、Echoが削除されたときにコールバック関数を実行
-export const setupDeleteEchoListener = (callback: (echoId: number, from: string) => void): (() => void) | undefined => {
-  getEthEchoContract().then(contract => {
-    if (contract) {
-      contract.on("DeleteEcho", callback);
-      return () => contract.off("DeleteEcho", callback);
-    }
-  });
+// export const setupDeleteEchoListener = (callback: (echoId: number, from: string) => void): (() => void) | undefined => {
+//   getEthEchoContract().then(contract => {
+//     if (contract) {
+//       contract.on("DeleteEcho", callback);
+//       return () => contract.off("DeleteEcho", callback);
+//     }
+//   });
 
-  return undefined;
-};
+//   return undefined;
+// };

--- a/contract/front/src/utils/ethereumUtils.ts
+++ b/contract/front/src/utils/ethereumUtils.ts
@@ -2,28 +2,13 @@ import { ethers } from "ethers";
 import abi from "../app/utils/EthEcho.json";
 // import { create } from 'kubo-rpc-client';
 import dotenv from 'dotenv';
+import { ProcessedEcho, RawEcho } from "@/app/types/type";
 
 dotenv.config();
 
 const contractAddress = "0x3Cd556A69C4908Cd1034d29c10D6250E712F1EB3";
 const contractABI = abi.abi;
 
-// ブロックチェーンから取得する生のEchoデータ（チェーン上に保存）
-interface RawEcho {
-  id: number;
-  echoer: string;
-  cid: string;
-  timestamp: number;
-}
-
-// IPFSからメッセージを取得し、加工後のEchoデータ
-interface ProcessedEcho {
-  id: number;
-  address: string;
-  timestamp: Date;
-  cid: string;
-  message: string | null;
-}
 export const getEthereumObject = () => (window as any).ethereum;
 
 export const connectWallet = async (): Promise<string | null> => {

--- a/contract/front/src/utils/profileContract.ts
+++ b/contract/front/src/utils/profileContract.ts
@@ -32,7 +32,20 @@ export const connectWallet = async (): Promise<string | null> => {
   }
 };
 
-export const getProfileContract = async () => {
+// 読み取り専用のコントラクト
+const getReadOnlyContract = async () => {
+  const provider = new ethers.JsonRpcProvider("https://eth-sepolia.g.alchemy.com/v2/0f3pgdhbIActNECtmQus8qUy6Gl6HbwT");
+    
+  // コントラクトのインスタンス化
+  return new ethers.Contract(
+    contractAddress,
+    contractABI,
+    provider
+  );
+}
+
+// 書き込み可能なコントラクト
+const getSignerontract = async () => {
   const ethereum = getEthereumObject();
   if (!ethereum) return null;
 
@@ -44,7 +57,7 @@ export const getProfileContract = async () => {
 // detailsCIDをスマートコントラクタに送信してオンチェーン保存する処理
 export async function updateProfileOnBlockchain(detailsCID: string): Promise<boolean> {
   try {
-    const contract = await getProfileContract();
+    const contract = await getSignerontract();
     if (!contract) return false;
 
     // スマートコントラクタに値を送信する処理
@@ -61,7 +74,7 @@ export async function updateProfileOnBlockchain(detailsCID: string): Promise<boo
 
 export async function getProfileFromBlockchain(address: string): Promise<ProcessedProfile | null> {
   try {
-    const contract = await getProfileContract();
+    const contract = await getReadOnlyContract();
     if (!contract) return null;
 
     const profile: RawProfile = await contract.getProfile(address);
@@ -78,7 +91,7 @@ export async function getProfileFromBlockchain(address: string): Promise<Process
 
 export async function hasProfileOnBlockchain(address: string): Promise<boolean> {
   try {
-    const contract = await getProfileContract();
+    const contract = await getReadOnlyContract();
     if (!contract) return false;
 
     return await contract.hasProfile(address);


### PR DESCRIPTION
## 概要
ウォレットを持っていなくても、読み取りのみは許可する

## 背景
これまではウォレットを持つユーザ専用のDappsであったが、参入障壁が高いため

## 実装方法
データ表示の処理のみ、読み取り専用コントラクトで行う
https://ethereum.stackexchange.com/questions/148872/a-way-to-view-smart-contract-data-without-needing-to-connect-wallet-to-dapp-in-e